### PR TITLE
Update test.sh to work on MacOS

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -2,18 +2,25 @@
 
 set -e
 
+PG_USER='postgres'
+UNAME_STR=`uname`
+if [[ "$UNAME_STR" == 'Darwin' ]]; then
+    PG_USER=`whoami`
+    echo "Using user '${PG_USER}' for postgres"
+fi
+
 export TEST_RDB_DIRECTORY=`mktemp -d 2>/dev/null || mktemp -d -t 'braid'`
 export RUST_BACKTRACE=1
 export SECRET=QkrDxgVJCT
-export TEST_POSTGRES_URL=postgres://postgres@localhost:5432/braid_test
+export TEST_POSTGRES_URL="postgres://${PG_USER}@localhost:5432/braid_test"
 
 ACTION=test
 
 while true; do
-  case "$1" in
-    --bench) ACTION=bench; shift ;;
-    * ) break ;;
-  esac
+    case "$1" in
+        --bench) ACTION=bench; shift ;;
+        * ) break ;;
+    esac
 done
 
 function cleanup {
@@ -25,5 +32,5 @@ mkdir -p $TEST_RDB_DIRECTORY
 trap cleanup EXIT
 
 dropdb --if-exists braid_test
-createdb --owner=postgres braid_test
+createdb --owner=$PG_USER braid_test
 cargo $ACTION $TEST_NAME


### PR DESCRIPTION
Added a similar chunk of code to what I did for `braidery/braid` to make `test.sh` work on MacOS.

I also changed the file to use 4-space tabs, since that seems like the default elsewhere in the codebase.